### PR TITLE
Feature/more broadcasting

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,9 +28,9 @@ version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "f94423c68f2e47db0d6f626a26d4872266e0ec3d"
+git-tree-sha1 = "2103e504f427e54ffa19af9ada225733a21f951f"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.2"
+version = "0.17.3"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RLEVectors"
 uuid = "17b45ede-fd0d-54ef-b825-8cf9fc64da95"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/RLEDataFrame-type.jl
+++ b/src/RLEDataFrame-type.jl
@@ -107,7 +107,7 @@ end
 function Base.getindex(x::RLEDataFrame, i, j)
     ind = index(x)
     j_inds = [ ind[x] for x in j ]
-    cols = [ RLEVector(x.columns[j_ind][i]) for j_ind in j_inds ] # FIXME: converting to RLEVector should not be necessary
+    cols = [ x.columns[j_ind][i] for j_ind in j_inds ]
     RLEDataFrame( cols, names(x)[j_inds] )
 end
 Base.getindex(x::RLEDataFrame, i::Integer, j::ColumnIndex) = x[j][i]

--- a/src/RLEVector-type.jl
+++ b/src/RLEVector-type.jl
@@ -93,8 +93,8 @@ const RLEVectorList{T1,T2} = Vector{ RLEVector{T1,T2} }
 Base.copy(x::RLEVector) = RLEVector(copy(x.runvalues), copy(x.runends))
 
 # similar
-function Base.similar(x::RLEVector)
-    copy(x)
+function Base.similar(a::RLEVector{T1,T2}, ::Type{T}, dims::Tuple{Int}) where {T1,T2,T}
+    RLEVector{T,T2}(Vector{T}(undef,1), [dims[1]])
 end
 
 # show

--- a/src/RLEVectors.jl
+++ b/src/RLEVectors.jl
@@ -1,5 +1,6 @@
 module RLEVectors
 
+using Base.Broadcast
 using Requires
 using Statistics
 using StatsBase
@@ -18,6 +19,7 @@ export       eltype, vcat, pop!, push!, popfirst!, pushfirst!, insert!, deleteat
 export deleterun!, decrement_run!
 
 # indexing
+import Base.Broadcast: BroadcastStyle, Broadcasted
 import Base: getindex, setindex!
 import Base: iterate
 export getindex, setindex!, ind2run, setrun!, ind2runcontext, RLERangesIterator, eachrange, tapply, iterate

--- a/src/group_generics.jl
+++ b/src/group_generics.jl
@@ -8,6 +8,8 @@ for op in summary_group
     end
 end
 
+struct RLEBroadcast <: Broadcast.BroadcastStyle end
+Base.BroadcastStyle(::Type{<:RLEVector}) = RLEBroadcast()
 Base.broadcast(f, x::RLEVector, y...) = RLEVector( [f(el,y...) for el in x.runvalues], ends(x) )
 function Base.broadcast(f, x::RLEVector, y::RLEVector)
     (runends, runvalues_x, runvalues_y) = disjoin(x, y)

--- a/src/group_generics.jl
+++ b/src/group_generics.jl
@@ -8,13 +8,15 @@ for op in summary_group
     end
 end
 
-struct RLEBroadcast <: Broadcast.BroadcastStyle end
-Base.BroadcastStyle(::Type{<:RLEVector}) = RLEBroadcast()
-Base.broadcast(f, x::RLEVector, y...) = RLEVector( [f(el,y...) for el in x.runvalues], ends(x) )
-function Base.broadcast(f, x::RLEVector, y::RLEVector)
-    (runends, runvalues_x, runvalues_y) = disjoin(x, y)
-    RLEVector( map(f,runvalues_x,runvalues_y), runends )
+Base.BroadcastStyle(::Type{<:RLEVector}) = Broadcast.ArrayStyle{RLEVector}()
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{RLEVector}}, ::Type{ElType}) where ElType
+    RLEVector(Vector{ElType}(undef,1), [size(bc)[1]])
 end
+#Base.broadcast(f, x::RLEVector, y...) = RLEVector( [f(el,y...) for el in x.runvalues], ends(x) )
+#function Base.broadcast(f, x::RLEVector, y::RLEVector)
+#    (runends, runvalues_x, runvalues_y) = disjoin(x, y)
+#    RLEVector( map(f,runvalues_x,runvalues_y), runends )
+#end
 Base.map(f, x::RLEVector) = RLEVector( map(f,x.runvalues), ends(x) )
 
 ## Methods that take two arguments, delegate to rle.runvalues and return something other than an RLEVector

--- a/src/group_generics.jl
+++ b/src/group_generics.jl
@@ -12,6 +12,14 @@ Base.BroadcastStyle(::Type{<:RLEVector}) = Broadcast.ArrayStyle{RLEVector}()
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{RLEVector}}, ::Type{ElType}) where ElType
     RLEVector(Vector{ElType}(undef,1), [size(bc)[1]])
 end
+function Base.copyto!(dest::RLEVector, bc::Broadcast.Broadcasted{Nothing})
+    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    res = Broadcast.preprocess(dest, bc)
+    for (i,x) in enumerate(res)
+        dest[i] = res[i]
+    end
+    dest
+end
 #Base.broadcast(f, x::RLEVector, y...) = RLEVector( [f(el,y...) for el in x.runvalues], ends(x) )
 #function Base.broadcast(f, x::RLEVector, y::RLEVector)
 #    (runends, runvalues_x, runvalues_y) = disjoin(x, y)

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -109,68 +109,68 @@ x = RLEVector([3,1,2,1,3])
 x[3] = 1
 @test collect(x) == [3,1,1,1,3]
 
-## range with scalar
-# in middle, no match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[10:11] .= 5
-@test x.runvalues == [1,2,3,5,3,4]
-@test x.runends == [4,8,9,11,12,16]
-
-# just left, no match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[9:10] = 5
-@test x.runvalues == [1,2,5,3,4]
-@test x.runends == [4,8,10,12,16]
-
-# just right, no match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[11:12] .= 5
-@test x.runvalues == [1,2,3,5,4]
-@test x.runends == [4,8,10,12,16]
-
-# just left, match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[9:10] .= 2
-@test x.runvalues == [1,2,3,4]
-@test x.runends == [4,10,12,16]
-
-# just right, match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[11:12] .= 4
-@test x.runvalues == [1,2,3,4]
-@test x.runends == [4,8,10,16]
-
-# span, no match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[9:12] .= 5
-@test x.runvalues == [1,2,5,4]
-@test x.runends == [4,8,12,16]
-
-# span, left match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[9:12] .= 2
-@test x.runvalues == [1,2,4]
-@test x.runends == [4,12,16]
-
-# span, right match
-x = RLEVector([1,2,3,4],[4,8,12,16])
-x[9:12] .= 4
-@test x.runvalues == [1,2,4]
-@test x.runends == [4,8,16]
-
-# span, both match
-x = RLEVector([1,2,3,2],[4,8,12,16])
-x[9:12] .= 2
-@test x.runvalues == [1,2]
-@test x.runends == [4,16]
-
-# reverse range with scalar
-x = RLEVector([1,2,3,4],[2,4,6,8])
-x[4:-1:2] .= 5
-@test collect(x) == [1,5,5,5,3,3,4,4]
-@test x.runvalues == [1,5,3,4]
-@test x.runends == [1,4,6,8]
-
+# ## range with scalar
+# # in middle, no match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[10:11] .= 5
+# @test x.runvalues == [1,2,3,5,3,4]
+# @test x.runends == [4,8,9,11,12,16]
+#
+# # just left, no match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[9:10] .= 5
+# @test x.runvalues == [1,2,5,3,4]
+# @test x.runends == [4,8,10,12,16]
+#
+# # just right, no match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[11:12] .= 5
+# @test x.runvalues == [1,2,3,5,4]
+# @test x.runends == [4,8,10,12,16]
+#
+# # just left, match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[9:10] .= 2
+# @test x.runvalues == [1,2,3,4]
+# @test x.runends == [4,10,12,16]
+#
+# # just right, match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[11:12] .= 4
+# @test x.runvalues == [1,2,3,4]
+# @test x.runends == [4,8,10,16]
+#
+# # span, no match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[9:12] .= 5
+# @test x.runvalues == [1,2,5,4]
+# @test x.runends == [4,8,12,16]
+#
+# # span, left match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[9:12] .= 2
+# @test x.runvalues == [1,2,4]
+# @test x.runends == [4,12,16]
+#
+# # span, right match
+# x = RLEVector([1,2,3,4],[4,8,12,16])
+# x[9:12] .= 4
+# @test x.runvalues == [1,2,4]
+# @test x.runends == [4,8,16]
+#
+# # span, both match
+# x = RLEVector([1,2,3,2],[4,8,12,16])
+# x[9:12] .= 2
+# @test x.runvalues == [1,2]
+# @test x.runends == [4,16]
+#
+# # reverse range with scalar
+# x = RLEVector([1,2,3,4],[2,4,6,8])
+# x[4:-1:2] .= 5
+# @test collect(x) == [1,5,5,5,3,3,4,4]
+# @test x.runvalues == [1,5,3,4]
+# @test x.runends == [1,4,6,8]
+#
 ## range with vector
 x = RLEVector([1,2,3,4],[2,4,6,8])
 x[2:4] = [5,6,7]
@@ -218,14 +218,14 @@ x[4:-1:2] = [5,6,7]
 # Colon
 x = RLEVector([1,2,3,4],[2,4,6,8])
 @test x[:] == x
-x[:] .= 4
-@test x == RLEVector([4 for i in 1:8])
+#x[:] .= 4
+#@test x == RLEVector([4 for i in 1:8])
 
 # Logical
 x = RLEVector([1,2],[2,4])
 @test x[ [ true,true,true,false ] ] == RLEVector([1,2],[2,3])
-x[ [true,true,true,false] ] .= 4
-@test x == RLEVector([4,4,4,2])
+#x[ [true,true,true,false] ] .= 4
+#@test x == RLEVector([4,4,4,2])
 x = RLEVector([1,2],[2,4])
 x[ [true,true,true,false] ] = [4,5,6]
 @test x == RLEVector([4,5,6,2])

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -109,67 +109,67 @@ x = RLEVector([3,1,2,1,3])
 x[3] = 1
 @test collect(x) == [3,1,1,1,3]
 
-# ## range with scalar
-# # in middle, no match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[10:11] .= 5
-# @test x.runvalues == [1,2,3,5,3,4]
-# @test x.runends == [4,8,9,11,12,16]
-#
-# # just left, no match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[9:10] = 5
-# @test x.runvalues == [1,2,5,3,4]
-# @test x.runends == [4,8,10,12,16]
-#
-# # just right, no match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[11:12] .= 5
-# @test x.runvalues == [1,2,3,5,4]
-# @test x.runends == [4,8,10,12,16]
-#
-# # just left, match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[9:10] .= 2
-# @test x.runvalues == [1,2,3,4]
-# @test x.runends == [4,10,12,16]
-#
-# # just right, match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[11:12] .= 4
-# @test x.runvalues == [1,2,3,4]
-# @test x.runends == [4,8,10,16]
-#
-# # span, no match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[9:12] .= 5
-# @test x.runvalues == [1,2,5,4]
-# @test x.runends == [4,8,12,16]
-#
-# # span, left match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[9:12] .= 2
-# @test x.runvalues == [1,2,4]
-# @test x.runends == [4,12,16]
-#
-# # span, right match
-# x = RLEVector([1,2,3,4],[4,8,12,16])
-# x[9:12] .= 4
-# @test x.runvalues == [1,2,4]
-# @test x.runends == [4,8,16]
-#
-# # span, both match
-# x = RLEVector([1,2,3,2],[4,8,12,16])
-# x[9:12] .= 2
-# @test x.runvalues == [1,2]
-# @test x.runends == [4,16]
-#
-# # reverse range with scalar
-# x = RLEVector([1,2,3,4],[2,4,6,8])
-# x[4:-1:2] .= 5
-# @test collect(x) == [1,5,5,5,3,3,4,4]
-# @test x.runvalues == [1,5,3,4]
-# @test x.runends == [1,4,6,8]
+## range with scalar
+# in middle, no match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[10:11] .= 5
+@test x.runvalues == [1,2,3,5,3,4]
+@test x.runends == [4,8,9,11,12,16]
+
+# just left, no match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[9:10] = 5
+@test x.runvalues == [1,2,5,3,4]
+@test x.runends == [4,8,10,12,16]
+
+# just right, no match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[11:12] .= 5
+@test x.runvalues == [1,2,3,5,4]
+@test x.runends == [4,8,10,12,16]
+
+# just left, match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[9:10] .= 2
+@test x.runvalues == [1,2,3,4]
+@test x.runends == [4,10,12,16]
+
+# just right, match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[11:12] .= 4
+@test x.runvalues == [1,2,3,4]
+@test x.runends == [4,8,10,16]
+
+# span, no match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[9:12] .= 5
+@test x.runvalues == [1,2,5,4]
+@test x.runends == [4,8,12,16]
+
+# span, left match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[9:12] .= 2
+@test x.runvalues == [1,2,4]
+@test x.runends == [4,12,16]
+
+# span, right match
+x = RLEVector([1,2,3,4],[4,8,12,16])
+x[9:12] .= 4
+@test x.runvalues == [1,2,4]
+@test x.runends == [4,8,16]
+
+# span, both match
+x = RLEVector([1,2,3,2],[4,8,12,16])
+x[9:12] .= 2
+@test x.runvalues == [1,2]
+@test x.runends == [4,16]
+
+# reverse range with scalar
+x = RLEVector([1,2,3,4],[2,4,6,8])
+x[4:-1:2] .= 5
+@test collect(x) == [1,5,5,5,3,3,4,4]
+@test x.runvalues == [1,5,3,4]
+@test x.runends == [1,4,6,8]
 
 ## range with vector
 x = RLEVector([1,2,3,4],[2,4,6,8])
@@ -216,19 +216,19 @@ x[4:-1:2] = [5,6,7]
 @test x[4:-1:2] == [5,6,7]
 
 # Colon
-# x = RLEVector([1,2,3,4],[2,4,6,8])
-# @test x[:] == x
-# x[:] .= 4
-# @test x == RLEVector([4 for i in 1:8])
+x = RLEVector([1,2,3,4],[2,4,6,8])
+@test x[:] == x
+x[:] .= 4
+@test x == RLEVector([4 for i in 1:8])
 
 # Logical
-# x = RLEVector([1,2],[2,4])
-# @test x[ [ true,true,true,false ] ] == x[ [1,2,3] ]
-# x[ [true,true,true,false] ] .= 4
-# @test x == RLEVector([4,4,4,2])
-# x = RLEVector([1,2],[2,4])
-# x[ [true,true,true,false] ] = [4,5,6]
-# @test x == RLEVector([4,5,6,2])
+x = RLEVector([1,2],[2,4])
+@test x[ [ true,true,true,false ] ] == x[ [1,2,3] ]
+x[ [true,true,true,false] ] .= 4
+@test x == RLEVector([4,4,4,2])
+x = RLEVector([1,2],[2,4])
+x[ [true,true,true,false] ] = [4,5,6]
+@test x == RLEVector([4,5,6,2])
 
 # eachrange iterator
 x = RLEVector([1, 1, 2, 2, 7, 12])

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -223,7 +223,7 @@ x[:] .= 4
 
 # Logical
 x = RLEVector([1,2],[2,4])
-@test x[ [ true,true,true,false ] ] == x[ [1,2,3] ]
+@test x[ [ true,true,true,false ] ] == RLEVector([1,2],[2,3])
 x[ [true,true,true,false] ] .= 4
 @test x == RLEVector([4,4,4,2])
 x = RLEVector([1,2],[2,4])

--- a/test/test_rledataframe.jl
+++ b/test/test_rledataframe.jl
@@ -21,7 +21,7 @@ z = RLEDataFrame( a=RLEVector([5,2,2]), b=RLEVector([4,4,4]), c=RLEVector([3,2,1
 @test_throws ArgumentError RLEDataFrame( [RLEVector([1])], [:a,:b] )
 @test_throws ArgumentError RLEDataFrame( [RLEVector([1]), RLEVector([2,3])], [:a,:b] )
 
-    # Getting and setting
+# Getting and setting
 z = RLEDataFrame( a=RLEVector([5,2,2]), b=RLEVector([4,4,4]), c=RLEVector([3,2,1]) )
 @test z[:] == z
 @test z[2] == RLEVector([4,4,4])

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -34,6 +34,10 @@ y = RLEVector([4,4,5,5,6,6])
 
 @test RLEVector(5,3) == RLEVector([5,5,5])
 
+sim = similar(RLEVector([1,2,3],[2,4,6]), Int32, (9))
+@test length(sim) == 9
+@test isa(values(sim), Vector{Int32}) == true
+
 # Conversion
 x = RLEVector([4,4,5,5,6,7,8])
 @test convert(Vector,x) == [4,4,5,5,6,7,8]


### PR DESCRIPTION
Added RLEBroadcast type with copyto! and similar methods.
Tightened signature for getindex(rle, vector, vector) so I could drop special function for case of subsetting by Vector{Bool}.
Subsetting by Vector{Bool} now returns RLEVector, as it should. Test updated.
These changes allow removal of the hack for RLEDataFrame where getindex-ed columns had to be made into RLEVector explicitly.