### PR TITLE
update `Requires` compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ DataFrames = "^0.20.0"
 Missings = "^0.4.3"
 OrderedCollections = "^1.1.0"
 Reexport = "^0.2.0"
-Requires = "^0.5.2"
+Requires = "^0.5.2, 1"
 StatsBase = "^0.32.0"
 julia = "1"
 


### PR DESCRIPTION
I'm guessing using `CompatHelper.jl` to update all entries could also help, but I needed this particular update to use latest `RLEVectors` with latest `Plots`.